### PR TITLE
Add ability to log to stdout

### DIFF
--- a/libs/default_settings.py
+++ b/libs/default_settings.py
@@ -24,6 +24,12 @@ SESSION_IGNORE_CHANGE_IP = False
 MAIL_ERROR_TO_WEBMASTER = False
 
 #
+# Logs
+#
+
+DEFAULT_LOG_LEVEL = "info"
+
+#
 # Syslog
 #
 # Syslog server address. Log to local syslog socket by default.
@@ -32,12 +38,21 @@ MAIL_ERROR_TO_WEBMASTER = False
 #   - /var/run/log on FreeBSD.
 # Some distro running systemd may have incorrect permission on /dev/log, it's
 # ok to use alternative syslog socket /run/systemd/journal/syslog instead.
+
+LOG_TO_SYSLOG = True
+
 SYSLOG_SERVER = "/dev/log"
 SYSLOG_PORT = 514
 
 # Syslog facility
 SYSLOG_FACILITY = "local5"
 SYSLOG_LOG_LEVEL = "info"
+
+#
+# Stdout log
+#
+LOG_TO_STDOUT = False
+STDOUT_LOG_LEVEL = "info"
 
 # Log programming error in SQL database, and viewed in `System -> Admin Log`.
 # This should be used only in testing server, not on production server, because

--- a/libs/logger.py
+++ b/libs/logger.py
@@ -12,25 +12,33 @@ session = web.config.get("_session")
 # Set application name.
 logger = logging.getLogger("iredadmin")
 
-# Set log level.
-_log_level = getattr(logging, str(settings.SYSLOG_LOG_LEVEL).upper())
-logger.setLevel(_log_level)
-
 # Log format
 _formatter = logging.Formatter("%(name)s %(message)s (%(pathname)s, line %(lineno)d)")
-_facility = getattr(SysLogHandler, "LOG_" + settings.SYSLOG_FACILITY.upper())
 
-if settings.SYSLOG_SERVER.startswith("/"):
-    # Log to a local socket
-    _handler = SysLogHandler(address=settings.SYSLOG_SERVER, facility=_facility)
-else:
-    # Log to a network address
-    _server = (settings.SYSLOG_SERVER, settings.SYSLOG_PORT)
-    _handler = SysLogHandler(address=_server, facility=_facility)
+# Set default log level.
+_default_log_level = getattr(logging, str(settings.DEFAULT_LOG_LEVEL).upper())
+logger.setLevel(_default_log_level)
 
-_handler.setFormatter(_formatter)
-logger.addHandler(_handler)
+if settings.LOG_TO_SYSLOG:
+    _syslog_facility = getattr(SysLogHandler, "LOG_" + settings.SYSLOG_FACILITY.upper())
 
+    if settings.SYSLOG_SERVER.startswith("/"):
+        # Log to a local socket
+        _syslog_handler = SysLogHandler(address=settings.SYSLOG_SERVER, facility=_syslog_facility)
+    else:
+        # Log to a network address
+        _server = (settings.SYSLOG_SERVER, settings.SYSLOG_PORT)
+        _syslog_handler = SysLogHandler(address=_server, facility=_syslog_facility)
+
+    _syslog_handler.setFormatter(_formatter)
+    _syslog_handler.setLevel(getattr(logging, str(settings.SYSLOG_LOG_LEVEL).upper()))
+    logger.addHandler(_syslog_handler)
+
+if settings.LOG_TO_STDOUT:
+    _stdout_handler = logging.StreamHandler(sys.stdout)
+    _stdout_handler.setFormatter(_formatter)
+    _stdout_handler.setLevel(getattr(logging, str(settings.STDOUT_LOG_LEVEL).upper()))
+    logger.addHandler(_stdout_handler)
 
 def log_traceback():
     exc_type, exc_value, exc_traceback = sys.exc_info()


### PR DESCRIPTION
I am working on a standalone Docker image for iRedAdmin and syslog does not work very well in Docker. The best practice with Docker is to log to stdout / stderr.

That said, this PR add some settings to log to syslog and/or to stdout.