### PR TITLE
Added no_proxy support

### DIFF
--- a/libs/default_settings.py
+++ b/libs/default_settings.py
@@ -67,11 +67,13 @@ HTTP_PROXY = ""
 
 # Set a comma-separated list of domain extensions or ip addresses that the proxy should not be used for
 # if iRedAdmin cannot access internet (iredmail.org) directly.
+#
+# Reference: https://docs.python.org/3/library/urllib.request.html#urllib.request.ProxyHandler
+#
 # Sample:
 #   - With dot notation: NO_PROXY = "localhost, 127.0.0.1, .mydomain.local"
-#   - With cidr notation: NO_PROXY = "localhost, 127.0.0.1, 192.168.86.0/24"
 #   - With fqdn: NO_PROXY = "localhost, 127.0.0.1, host.mydomain.local"
-NO_PROXY = "localhost, 127.0.0.1"
+NO_PROXY = "localhost, 127.0.0.1, ::1"
 
 # Local timezone. It must be one of below:
 #   GMT-12:00

--- a/libs/default_settings.py
+++ b/libs/default_settings.py
@@ -71,8 +71,8 @@ HTTP_PROXY = ""
 # Reference: https://docs.python.org/3/library/urllib.request.html#urllib.request.ProxyHandler
 #
 # Sample:
-#   - With dot notation: NO_PROXY = "localhost, 127.0.0.1, .mydomain.local"
-#   - With fqdn: NO_PROXY = "localhost, 127.0.0.1, host.mydomain.local"
+#   - With dot notation: NO_PROXY = "localhost, 127.0.0.1, ::1, .mydomain.local"
+#   - With fqdn: NO_PROXY = "localhost, 127.0.0.1, ::1, host.mydomain.local"
 NO_PROXY = "localhost, 127.0.0.1, ::1"
 
 # Local timezone. It must be one of below:

--- a/libs/default_settings.py
+++ b/libs/default_settings.py
@@ -65,6 +65,14 @@ SKIN = "default"
 #   - With authentication: HTTP_PROXY = "http://user:password@192.168.1.1:3128"
 HTTP_PROXY = ""
 
+# Set a comma-separated list of domain extensions or ip addresses that the proxy should not be used for
+# if iRedAdmin cannot access internet (iredmail.org) directly.
+# Sample:
+#   - With dot notation: NO_PROXY = "localhost, 127.0.0.1, .mydomain.local"
+#   - With cidr notation: NO_PROXY = "localhost, 127.0.0.1, 192.168.86.0/24"
+#   - With fqdn: NO_PROXY = "localhost, 127.0.0.1, host.mydomain.local"
+NO_PROXY = "localhost, 127.0.0.1"
+
 # Local timezone. It must be one of below:
 #   GMT-12:00
 #   GMT-11:00

--- a/libs/sysinfo.py
+++ b/libs/sysinfo.py
@@ -37,13 +37,13 @@ def get_iredmail_version():
 
 
 def __get_proxied_urlopen():
-    socket.setdefaulttimeout(5)
+    socket.setdefaulttimeout(5):
 
-    if settings.HTTP_PROXY:
+    if getattr(settings, "HTTP_PROXY", ""):
         # urllib2 adds proxy handlers with environment variables automatically
-        os.environ["http_proxy"] = settings.HTTP_PROXY
-        os.environ["https_proxy"] = settings.HTTP_PROXY
-        os.environ["no_proxy"] = settings.NO_PROXY if settings.NO_PROXY else "localhost, 127.0.0.1"
+        os.environ["http_proxy"] = getattr(settings, "HTTP_PROXY")
+        os.environ["https_proxy"] = getattr(settings, "HTTP_PROXY")
+        os.environ["no_proxy"] = getattr(settings, "NO_PROXY", "localhost, 127.0.0.1")
 
     return urllib.request.urlopen
 

--- a/libs/sysinfo.py
+++ b/libs/sysinfo.py
@@ -43,6 +43,7 @@ def __get_proxied_urlopen():
         # urllib2 adds proxy handlers with environment variables automatically
         os.environ["http_proxy"] = settings.HTTP_PROXY
         os.environ["https_proxy"] = settings.HTTP_PROXY
+        os.environ["no_proxy"] = settings.NO_PROXY if settings.NO_PROXY else "localhost, 127.0.0.1"
 
     return urllib.request.urlopen
 

--- a/libs/sysinfo.py
+++ b/libs/sysinfo.py
@@ -37,7 +37,7 @@ def get_iredmail_version():
 
 
 def __get_proxied_urlopen():
-    socket.setdefaulttimeout(5):
+    socket.setdefaulttimeout(5)
 
     if getattr(settings, "HTTP_PROXY", ""):
         # urllib2 adds proxy handlers with environment variables automatically

--- a/libs/sysinfo.py
+++ b/libs/sysinfo.py
@@ -43,7 +43,7 @@ def __get_proxied_urlopen():
         # urllib2 adds proxy handlers with environment variables automatically
         os.environ["http_proxy"] = getattr(settings, "HTTP_PROXY")
         os.environ["https_proxy"] = getattr(settings, "HTTP_PROXY")
-        os.environ["no_proxy"] = getattr(settings, "NO_PROXY", "localhost, 127.0.0.1")
+        os.environ["no_proxy"] = getattr(settings, "NO_PROXY", "localhost, 127.0.0.1, ::1")
 
     return urllib.request.urlopen
 


### PR DESCRIPTION
Added the ability to define `no_proxy` variable to exclude addresses if `http_proxy` is defined. This is useful for clustered iRedMail components on air gapped environments.

The PR fixes an "internal server error" observed in iRedAdmin web ui or API while fetching user information if the `HTTP_PROXY`
 variable is defined. Below you can see that the API request from iRedAdmin to mlmmjadmin is being proxied.

![image](https://user-images.githubusercontent.com/9947828/233320931-9ffcc339-f481-4158-8511-4ad2cd20c471.png)

> The code is tested with iRedAdmin-PRO OpenLDAP v.5.4.1
